### PR TITLE
Add support for the (beta) Catalogs API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ reponse.uri
   * [Create](#campaigns-create)
   * [Metrics](#campaigns-metrics)
   * [Child Campaigns](#campaigns-child)
+* [Catalogs](#catalogs)
+  * [Field Mappings](#catalog-field-mappings)
+  * [Update Field Mappings](#catalog-update-field-mappings)
+  * [Create](#catalog-create)
+  * [Delete](#catalog-delete)
+  * [Items](#catalog-items)
+  * [Get](#catalog-get)
+  * [Add/Update](#catalog-add-update)
+  * [Add/Replace](#catalog-add-replace)
+  * [Bulk Add/Update](#catalog-bulk-add-update)
+  * [Remove](#catalog-remove)
+  * [Bulk Remove](#catalog-bulk-remove)
 * [Channels](#channels)
   * [All](#channels-all)
 * [Commerce](#commerce)
@@ -210,6 +222,109 @@ Endpoint: `GET /channels`
 ```ruby
 channels = Iterable::Channels.new
 response = channels.all
+```
+
+### Catalogs
+
+_Note: This API is currently only available when using a token for a project that has been added to the Catalogs beta._
+
+#### Catalog Field Mappings
+
+Endpoint: `GET /api/catalogs/catalog-name/fieldMappings`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.field_mappings
+```
+
+#### Catalog Update Field Mappings
+
+Endpoint: `PUT /api/catalogs/catalog-name/fieldMappings`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.update_field_mappings([{fieldName: 'orange', fieldType: 'string'}])
+```
+
+#### Catalog Create
+
+Endpoint: `POST /api/catalogs/catalog-name`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.create
+```
+
+#### Catalog Delete
+
+Endpoint: `DELETE /api/catalogs/catalog-name`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.delete
+```
+
+#### Catalog Items
+
+Endpoint: `GET /api/catalogs/catalog-name/items`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.items
+```
+
+#### Catalog Get
+
+Endpoint: `GET /api/catalogs/catalog-name/items/key`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.get(123)
+```
+
+#### Catalog Add/Update
+
+Endpoint: `PATCH /api/catalogs/catalog-name/items/key`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.update(123, orange: 'slice')
+```
+
+#### Catalog Add/Replace
+
+Endpoint: `PUT /api/catalogs/catalog-name/items/key`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.replace(123, orange: 'slice')
+```
+
+#### Catalog Bulk Add/Update
+
+Endpoint: `POST /api/catalogs/catalog-name/items`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.bulk_create(documents: { 123 => { orange: 'slice' }, 456 => { 'orange' => 'julius' })
+```
+
+#### Catalog Remove
+
+Endpoint: `DELETE /api/catalogs/catalog-name/items/key`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.remove(123)
+```
+
+#### Catalog Bulk Remove
+
+Endpoint: `DELETE /api/catalogs/catalog-name/items`
+
+```ruby
+catalog = Iterable::Catalog.new('catalog-name')
+response = catalog.bulk_remove(123, 456)
 ```
 
 ### Commerce

--- a/lib/iterable.rb
+++ b/lib/iterable.rb
@@ -11,6 +11,7 @@ files = %w[
   request
   lists
   campaigns
+  catalog
   channels
   events
   message_types

--- a/lib/iterable/catalog.rb
+++ b/lib/iterable/catalog.rb
@@ -1,0 +1,188 @@
+module Iterable
+  ##
+  #
+  # Interact with /catalogs/{catalogName} API endpoints
+  #
+  # @example Creating catalog endpoint object
+  #   # With default config
+  #   templates = Iterable::Catalog.new "catalog-name"
+  #   templates.items
+  #
+  #   # With custom config
+  #   conf = Iterable::Config.new(token: 'new-token')
+  #   templates = Iterable::Catalog.new("catalog-name", config)
+  class Catalog < ApiResource
+    attr_reader :name
+    ##
+    #
+    # Initialize a Catalog with a table name
+    #
+    # @param name [String] The name of the table to interact with
+    # @param conf [Iterable::Config] A config to optionally pass for requests
+    #
+    # @return [Iterable::Catalog]
+    def initialize(name, conf = nil)
+      @name = name
+      super conf
+    end
+
+    ##
+    #
+    # Get field mappings for a catalog
+    #
+    # @return [Iterable::Response] A response object
+    def field_mappings
+      Iterable.request(conf, "#{base_path}/fieldMappings").get
+    end
+
+    ##
+    #
+    # Set a catalog's field mappings (data types)
+    #
+    # @return [Iterable::Response] A response object
+    def update_field_mappings(mappings_updates)
+      body = { mappingsUpdates: mappings_updates.is_a?(Array) ? mappings_updates : [mappings_updates] }
+      Iterable.request(conf, "#{base_path}/fieldMappings").put(body)
+    end
+
+    ##
+    #
+    # Delete a catalog
+    #
+    # @return [Iterable::Response] A response object
+    def delete
+      Iterable.request(conf, base_path).delete
+    end
+
+    ##
+    #
+    # Create a catalog
+    #
+    # @return [Iterable::Response] A response object
+    def create
+      Iterable.request(conf, base_path).post
+    end
+
+    ##
+    #
+    # Delete a catalog item
+    #
+    # @return [Iterable::Response] A response object
+    def remove(key)
+      Iterable.request(conf, base_path(key)).delete
+    end
+
+    ##
+    #
+    # Get a specific catalog item
+    #
+    # @param key [String] Key of catalog item to get
+    #
+    # @return [Iterable::Response] A response object
+    def get(key)
+      Iterable.request(conf, base_path(key)).get
+    end
+
+    ##
+    #
+    # Create or update a catalog item
+    #
+    # Asynchronous. Create or update the specified catalog item in the given catalog.
+    # A catalog item's ID must be unique, contain only alphanumeric characters and
+    # dashes, and have a maximum length of 255 characters.
+    #
+    # If the catalog item already exists, its fields will be updated with the values
+    # provided in the request body. Previously existing fields not included in the
+    # request body will remain as is. Do not use periods in field names.
+    #
+    # @param key [String] Key of metadata to add
+    # @param value [Hash] JSON representation of catalog item to update.
+    #
+    # @return [Iterable::Response] A response object
+    def update(key, value = {})
+      Iterable.request(conf, base_path(key)).patch(update: value)
+    end
+
+    ##
+    #
+    # Create or replace a catalog item
+    #
+    # Asynchronous. Create or replace the specified catalog item in the given catalog.
+    # A catalog item's ID must be unique, contain only alphanumeric characters and
+    # dashes, and have a maximum length of 255 characters.
+    #
+    # If the catalog item already exists, it will be replaced by the value provided
+    # in the request body. Do not use periods in field names.
+    #
+    # @param key [String] Key of metadata to add
+    # @param value [Hash] JSON representation of catalog item to update.
+    #
+    # @return [Iterable::Response] A response object
+    def replace(key, value = {})
+      Iterable.request(conf, base_path(key)).put(value: value)
+    end
+
+    ##
+    #
+    # Bulk delete catalog items
+    #
+    # @param keys [Array] Array of catalog items to delete
+    #
+    # @return [Iterable::Response] A response object
+    def bulk_remove(*keys)
+      body = { itemIds: Array(*keys).map(&:to_s) }
+      Iterable.request(conf, "#{base_path}/items").delete(body)
+    end
+
+    ##
+    #
+    # Get the catalog items for a catalog
+    #
+    # @param page [Integer] Page number to list (starting at 1)
+    # @param page_size [Integer] Number of results to display per page (defaults to 10)
+    # @param order [String] Field by which results should be ordered. To also use the sortAscending parameter, this field must have a defined type.
+    # @param sort_ascending [Boolean] Sort results by ascending (Defaults to false)
+    #
+    # @return [Iterable::Response] A response object
+    def items(page: 1, page_size: 10, order: nil, sort_ascending: false)
+      params = {}
+      params[:page] = page if page
+      params[:pageSize] = page_size if page_size
+      params[:orderBy] = order if order
+      params[:sortAscending] = sort_ascending if sort_ascending != nil
+      Iterable.request(conf, "#{base_path}/items", params).get
+    end
+
+    ##
+    #
+    # Bulk create catalog items
+    #
+    # Asynchronous. Create up to 1000 catalog items with a single request.
+    # Each of a catalog's items must have a unique ID that contains only
+    # alphanumeric characters and dashes and has a maximum length of 255
+    # characters. If the catalog already contains an item with the same ID as
+    # one provided in the request body, the item in the catalog will be
+    # completely overwritten, unless replaceUploadedFieldsOnly is set to
+    # true. Do not use periods in field names.
+    #
+    # @param documents [Hash] Hash mapping keys to value objects
+    # @param replace_uploaded_fields_only [Boolean] Whether to replace only the upload fields within each document, not each entire document
+    #
+    # @return [Iterable::Response] A response object
+    def bulk_create(documents: {}, replace_uploaded_fields_only: true)
+      body = {
+        documents: documents,
+        replaceUploadedFieldsOnly: replace_uploaded_fields_only
+      }
+      Iterable.request(conf, "#{base_path}/items").post(body)
+    end
+
+    private
+
+    def base_path(key = nil)
+      path = "/catalogs/#{@name}"
+      path += "/items/#{key}" if key
+      path
+    end
+  end
+end

--- a/lib/iterable/request.rb
+++ b/lib/iterable/request.rb
@@ -34,8 +34,8 @@ module Iterable
       execute :put, body, headers
     end
 
-    def delete(headers = {})
-      execute :delete, {}, headers
+    def delete(body = {}, headers = {})
+      execute :delete, body, headers
     end
 
     private

--- a/lib/iterable/request.rb
+++ b/lib/iterable/request.rb
@@ -34,6 +34,10 @@ module Iterable
       execute :put, body, headers
     end
 
+    def patch(body = {}, headers = {})
+      execute :patch, body, headers
+    end
+
     def delete(body = {}, headers = {})
       execute :delete, body, headers
     end

--- a/spec/cassettes/Iterable_Catalog/bulk_create/non-existing_catalog/returns_404.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/non-existing_catalog/returns_404.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:10:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '160'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"You are trying to access catalog example-catalog, but it does
+        not yet exist. Please see our API docs to explicitly create the catalog.","code":"NotFound","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:10:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/creates_the_records.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/creates_the_records.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:30:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2887'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1194,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:30:12 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:30:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '19'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:30:12 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:31:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":35,"lastModified":1560965412000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:31:13 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:31:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","size":33,"lastModified":1560965412000,"value":{"orange":"slice","lemon":"head"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:31:13 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:31:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '957'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:31:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/responds_with_success.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:10:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2021'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1184,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:10:55 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:10:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:10:55 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:10:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2343'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:10:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_entire_records_fields/adds_new_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_entire_records_fields/adds_new_fields.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:20:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2942'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1191,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:20:24 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:20:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:20:25 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:20:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:20:45 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":35,"lastModified":1560964845000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:06 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '938'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_entire_records_fields/removes_extra_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_entire_records_fields/removes_extra_fields.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2007'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1192,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:10 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:10 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:31 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":35,"lastModified":1560964891000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:51 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '930'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_entire_records_fields/updates_existing_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_entire_records_fields/updates_existing_fields.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1984'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1193,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:55 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:21:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:21:55 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:22:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:22:15 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:22:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":35,"lastModified":1560964935000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:22:36 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:22:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '932'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:22:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_only_uploaded_fields/adds_new_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_only_uploaded_fields/adds_new_fields.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3820'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1186,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:48 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '26'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:48 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:12:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '28'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:12:09 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:12:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '163'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":50,"lastModified":1560964328000,"value":{"lime":"juice","lemon":"wedge","orange":"julius"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:12:29 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:12:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '951'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:12:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_only_uploaded_fields/leaves_unmodified_fields_alone.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_only_uploaded_fields/leaves_unmodified_fields_alone.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2215'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1185,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:00 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:01 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '19'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:21 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":50,"lastModified":1560964281000,"value":{"lime":"juice","lemon":"wedge","orange":"julius"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:42 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:11:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '941'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:11:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_only_uploaded_fields/updates_existing_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_create/with_an_existing_catalog/with_an_existing_record/when_replacing_only_uploaded_fields/updates_existing_fields.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:12:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2054'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1187,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:12:33 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:12:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:12:33 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"documents":{"1":{"orange":"julius","lemon":"wedge"},"2":{"orange":"slice","lemon":"head"}},"replaceUploadedFieldsOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:12:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Request to bulk-upload documents into example-catalog processed
+        successfully","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:12:53 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:13:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","size":50,"lastModified":1560964373000,"value":{"lime":"juice","lemon":"wedge","orange":"julius"}}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:13:14 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 17:13:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '936'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 17:13:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_remove/non-existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_remove/non-existing_catalog/responds_with_success.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"itemIds":["123"]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:34:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '121'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully received request to delete 1 items from catalog
+        example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:34:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_remove/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_remove/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:34:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1874'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1033,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:34:53 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"itemIds":["123"]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:34:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '121'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully received request to delete 1 items from catalog
+        example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:34:53 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:34:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2813'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:34:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/bulk_remove/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/bulk_remove/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
@@ -1,0 +1,168 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:35:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3825'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1034,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:35:00 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"foo":"bar"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:35:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:35:00 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"itemIds":["123"]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:36:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '121'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully received request to delete 1 items from catalog
+        example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:36:01 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:36:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '855'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:36:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/create/creating_a_duplciate_catalog/fails.yml
+++ b/spec/cassettes/Iterable_Catalog/create/creating_a_duplciate_catalog/fails.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2713'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":966,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:33 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Unable to create a catalog with name: example-catalog. Make
+        sure the catalog name is unique.","code":"BadParams","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:34 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '926'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/create/creating_a_duplciate_catalog/false.yml
+++ b/spec/cassettes/Iterable_Catalog/create/creating_a_duplciate_catalog/false.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2725'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":965,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:05 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Unable to create a catalog with name: example-catalog. Make
+        sure the catalog name is unique.","code":"BadParams","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:05 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '866'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/create/creating_a_duplicate_catalog/fails_with_code_400.yml
+++ b/spec/cassettes/Iterable_Catalog/create/creating_a_duplicate_catalog/fails_with_code_400.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:57:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3508'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":967,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:57:27 GMT
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:57:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Unable to create a catalog with name: example-catalog. Make
+        sure the catalog name is unique.","code":"BadParams","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:57:27 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:57:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '868'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:57:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/create/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/create/responds_with_success.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3454'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":964,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:01 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:56:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '873'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:56:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/delete/non-existing_catalog/fails.yml
+++ b/spec/cassettes/Iterable_Catalog/delete/non-existing_catalog/fails.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:59:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog elbatelpmaxe","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:59:30 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/delete/with_an_existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/delete/with_an_existing_catalog/responds_with_success.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3789'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":984,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:18 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '865'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/delete/with_an_existing_catalog/successful/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/delete/with_an_existing_catalog/successful/responds_with_success.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:59:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3642'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":968,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:59:33 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:59:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '872'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:59:35 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/fails.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/fails.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"An error occured. Please try again later. If problem persists,
+        please contact your CSM","code":"GenericError","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/fails_with_code_500.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/fails_with_code_500.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"An error occured. Please try again later. If problem persists,
+        please contact your CSM","code":"GenericError","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:14 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"An error occured. Please try again later. If problem persists,
+        please contact your CSM","code":"GenericError","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/responds_with_code_500.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/responds_with_code_500.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"An error occured. Please try again later. If problem persists,
+        please contact your CSM","code":"GenericError","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/returns_an_error_message.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/non-existing_catalog/returns_an_error_message.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"An error occured. Please try again later. If problem persists,
+        please contact your CSM","code":"GenericError","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3540'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":981,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:06 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '95'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:06 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '852'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/returns_a_list_of_undefined_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/returns_a_list_of_undefined_fields.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1693'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":983,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:13 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '95'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:13 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '870'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/returns_defined_mappings.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/returns_defined_mappings.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2714'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":982,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:10 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '95'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:10 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '879'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/successful/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/successful/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:59:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":973,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:59:56 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:59:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '95'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '16'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:59:56 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 01:59:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '862'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 01:59:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/successful/returns_a_list_of_undefined_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/successful/returns_a_list_of_undefined_fields.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2701'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":974,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:00 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '95'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:00 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '873'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/successful/returns_defined_mappings.yml
+++ b/spec/cassettes/Iterable_Catalog/field_mappings/with_an_existing_catalog/successful/returns_defined_mappings.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2514'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":975,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:04 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '95'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:04 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:00:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '867'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:00:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/get/non-existing_catalog/returns_404.yml
+++ b/spec/cassettes/Iterable_Catalog/get/non-existing_catalog/returns_404.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:17:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '110'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"No catalog item found in catalog example-catalog with itemId
+        123","code":"NotFound","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:17:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/get/with_an_existing_catalog/for_a_non-existant_key/returns_404.yml
+++ b/spec/cassettes/Iterable_Catalog/get/with_an_existing_catalog/for_a_non-existant_key/returns_404.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:17:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3822'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":999,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:17:35 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:17:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '110'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"No catalog item found in catalog example-catalog with itemId
+        123","code":"NotFound","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:17:35 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:17:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '936'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:17:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/get/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/get/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:25:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3821'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1004,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:25:47 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"foo":"bar"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:25:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:25:47 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:26:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '147'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":13,"lastModified":1559355947000,"value":{"foo":"bar"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:26:48 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:26:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '895'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:26:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/get/with_an_existing_catalog/for_an_existing_key/returns_the_requested_item.yml
+++ b/spec/cassettes/Iterable_Catalog/get/with_an_existing_catalog/for_an_existing_key/returns_the_requested_item.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:28:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3636'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1005,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:28:38 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"foo":"bar"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:28:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:28:39 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:29:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":13,"lastModified":1559356119000,"value":{"foo":"bar"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:29:39 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:29:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '881'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:29:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/non-existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/items/non-existing_catalog/responds_with_success.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&page=1&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '160'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"You are trying to access catalog example-catalog, but it does
+        not yet exist. Please see our API docs to explicitly create the catalog.","code":"NotFound","params":null}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:41 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key&page=1&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:19:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Invalid API key","code":"BadApiKey","params":{"ip":"174.140.175.245","endpoint":"/api/catalogs/example-catalog/items"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:19:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/non-existing_catalog/returns_404.yml
+++ b/spec/cassettes/Iterable_Catalog/items/non-existing_catalog/returns_404.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&page=1&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:22:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '160'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"You are trying to access catalog example-catalog, but it does
+        not yet exist. Please see our API docs to explicitly create the catalog.","code":"NotFound","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:22:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/responds_with_success.yml
@@ -1,0 +1,1399 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3780'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1066,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":1}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '32'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":2}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","url":"/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":3}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"3","url":"/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:48 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":4}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '17'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"4","url":"/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:48 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":5}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"5","url":"/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:50 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":6}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"6","url":"/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:50 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":7}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"7","url":"/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:50 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":8}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"8","url":"/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:51 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":9}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"9","url":"/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:51 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":10}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"10","url":"/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:52 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":11}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"11","url":"/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:52 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":12}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"12","url":"/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:53 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":13}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"13","url":"/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:55 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":14}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"14","url":"/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:55 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":15}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"15","url":"/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:55 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":16}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"16","url":"/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:56 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":17}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"17","url":"/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:56 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":18}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"18","url":"/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:57 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":19}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"19","url":"/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:58 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":20}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '20'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"20","url":"/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:58 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":21}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"21","url":"/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:59 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":22}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:07:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"22","url":"/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:07:59 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":23}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '16'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"23","url":"/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:00 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":24}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"24","url":"/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:00 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":25}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"25","url":"/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:01 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":26}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"26","url":"/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:01 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":27}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"27","url":"/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:02 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":28}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"28","url":"/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:02 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":29}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"29","url":"/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:02 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":30}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"30","url":"/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:02 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:08:03 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        Json error: {"obj.mappingsUpdates[0]":[{"msg":["error.expected.jsobject"],"args":[]}],"obj.mappingsUpdates[1]":[{"msg":["error.expected.jsobject"],"args":[]}]}
+         {"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:08:03 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&page=1&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '339'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogItemsWithProperties":[{"catalogName":"example-catalog","itemId":"29","size":13,"lastModified":1559574482000,"value":{"number":29}},{"catalogName":"example-catalog","itemId":"28","size":13,"lastModified":1559574482000,"value":{"number":28}},{"catalogName":"example-catalog","itemId":"30","size":13,"lastModified":1559574482000,"value":{"number":30}},{"catalogName":"example-catalog","itemId":"25","size":13,"lastModified":1559574481000,"value":{"number":25}},{"catalogName":"example-catalog","itemId":"26","size":13,"lastModified":1559574481000,"value":{"number":26}},{"catalogName":"example-catalog","itemId":"27","size":13,"lastModified":1559574481000,"value":{"number":27}},{"catalogName":"example-catalog","itemId":"23","size":13,"lastModified":1559574480000,"value":{"number":23}},{"catalogName":"example-catalog","itemId":"24","size":13,"lastModified":1559574480000,"value":{"number":24}},{"catalogName":"example-catalog","itemId":"21","size":13,"lastModified":1559574479000,"value":{"number":21}},{"catalogName":"example-catalog","itemId":"22","size":13,"lastModified":1559574479000,"value":{"number":22}}],"totalItemsCount":30,"nextPageUrl":"/api/catalogs/example-catalog/items?pageSize=10&sortAscending=false&api_key=<ITERABLE_TOKEN>&page=2"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:06 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '871'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/returns_the_first_page_of_items.yml
+++ b/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/returns_the_first_page_of_items.yml
@@ -1,0 +1,1399 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3600'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1067,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:13 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":1}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:13 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":2}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '16'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","url":"/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:13 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":3}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"3","url":"/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:13 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":4}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"4","url":"/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:14 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":5}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"5","url":"/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:15 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":6}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"6","url":"/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:15 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":7}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"7","url":"/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:15 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":8}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"8","url":"/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:15 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":9}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"9","url":"/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:15 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":10}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"10","url":"/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:16 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":11}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"11","url":"/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:16 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":12}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"12","url":"/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:16 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":13}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"13","url":"/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:16 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":14}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"14","url":"/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:16 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":15}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"15","url":"/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:17 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":16}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '22'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"16","url":"/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:18 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":17}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"17","url":"/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:19 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":18}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"18","url":"/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:19 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":19}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"19","url":"/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:20 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":20}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"20","url":"/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:20 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":21}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"21","url":"/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:20 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":22}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"22","url":"/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:21 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":23}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"23","url":"/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:22 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":24}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"24","url":"/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:22 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":25}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"25","url":"/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:23 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":26}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"26","url":"/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:23 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":27}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"27","url":"/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:23 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":28}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"28","url":"/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:24 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":29}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"29","url":"/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:24 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":30}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"30","url":"/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:24 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:09:24 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        Json error: {"obj.mappingsUpdates[0]":[{"msg":["error.expected.jsobject"],"args":[]}],"obj.mappingsUpdates[1]":[{"msg":["error.expected.jsobject"],"args":[]}]}
+         {"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:09:24 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&page=1&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '341'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogItemsWithProperties":[{"catalogName":"example-catalog","itemId":"29","size":13,"lastModified":1559574564000,"value":{"number":29}},{"catalogName":"example-catalog","itemId":"30","size":13,"lastModified":1559574564000,"value":{"number":30}},{"catalogName":"example-catalog","itemId":"25","size":13,"lastModified":1559574563000,"value":{"number":25}},{"catalogName":"example-catalog","itemId":"26","size":13,"lastModified":1559574563000,"value":{"number":26}},{"catalogName":"example-catalog","itemId":"27","size":13,"lastModified":1559574563000,"value":{"number":27}},{"catalogName":"example-catalog","itemId":"28","size":13,"lastModified":1559574563000,"value":{"number":28}},{"catalogName":"example-catalog","itemId":"23","size":13,"lastModified":1559574562000,"value":{"number":23}},{"catalogName":"example-catalog","itemId":"24","size":13,"lastModified":1559574562000,"value":{"number":24}},{"catalogName":"example-catalog","itemId":"22","size":13,"lastModified":1559574561000,"value":{"number":22}},{"catalogName":"example-catalog","itemId":"20","size":13,"lastModified":1559574560000,"value":{"number":20}}],"totalItemsCount":30,"nextPageUrl":"/api/catalogs/example-catalog/items?pageSize=10&sortAscending=false&api_key=<ITERABLE_TOKEN>&page=2"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:26 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '876'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_given_order/and_ascending_sort/sorts_the_items_ascending.yml
+++ b/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_given_order/and_ascending_sort/sorts_the_items_ascending.yml
@@ -1,0 +1,1397 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3946'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1181,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:33 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[{"fieldName":"number","fieldType":"long"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '199'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:34 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":1}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '17'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:34 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":2}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","url":"/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":3}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"3","url":"/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":4}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"4","url":"/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:36 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":5}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"5","url":"/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:37 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":6}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"6","url":"/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:37 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":7}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"7","url":"/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":8}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"8","url":"/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":9}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"9","url":"/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":10}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"10","url":"/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":11}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"11","url":"/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":12}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"12","url":"/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":13}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"13","url":"/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":14}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"14","url":"/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":15}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"15","url":"/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":16}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"16","url":"/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":17}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '36'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"17","url":"/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:42 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":18}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"18","url":"/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:42 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":19}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"19","url":"/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:42 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":20}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"20","url":"/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:43 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":21}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"21","url":"/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:43 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":22}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"22","url":"/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":23}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"23","url":"/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":24}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"24","url":"/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":25}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"25","url":"/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":26}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"26","url":"/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":27}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"27","url":"/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":28}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"28","url":"/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":29}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"29","url":"/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":30}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:44:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"30","url":"/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:44:47 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&orderBy=number&page=1&pageSize=10&sortAscending=true
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:45:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '349'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '128'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogItemsWithProperties":[{"catalogName":"example-catalog","itemId":"1","size":12,"lastModified":1560962674000,"value":{"number":1}},{"catalogName":"example-catalog","itemId":"2","size":12,"lastModified":1560962675000,"value":{"number":2}},{"catalogName":"example-catalog","itemId":"3","size":12,"lastModified":1560962675000,"value":{"number":3}},{"catalogName":"example-catalog","itemId":"4","size":12,"lastModified":1560962676000,"value":{"number":4}},{"catalogName":"example-catalog","itemId":"5","size":12,"lastModified":1560962677000,"value":{"number":5}},{"catalogName":"example-catalog","itemId":"6","size":12,"lastModified":1560962677000,"value":{"number":6}},{"catalogName":"example-catalog","itemId":"7","size":12,"lastModified":1560962678000,"value":{"number":7}},{"catalogName":"example-catalog","itemId":"8","size":12,"lastModified":1560962678000,"value":{"number":8}},{"catalogName":"example-catalog","itemId":"9","size":12,"lastModified":1560962679000,"value":{"number":9}},{"catalogName":"example-catalog","itemId":"10","size":13,"lastModified":1560962679000,"value":{"number":10}}],"totalItemsCount":30,"nextPageUrl":"/api/catalogs/example-catalog/items?pageSize=10&orderBy=number&sortAscending=true&api_key=<ITERABLE_TOKEN>&page=2"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:45:51 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:45:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '949'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:45:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_given_order/and_non-ascending_sort/sorts_the_items_descending.yml
+++ b/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_given_order/and_non-ascending_sort/sorts_the_items_descending.yml
@@ -1,0 +1,1397 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2150'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1182,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:32 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[{"fieldName":"number","fieldType":"long"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1937'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":1}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":2}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","url":"/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":3}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"3","url":"/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:36 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":4}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"4","url":"/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:36 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":5}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"5","url":"/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:36 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":6}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"6","url":"/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:37 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":7}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"7","url":"/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:37 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":8}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"8","url":"/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":9}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"9","url":"/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":10}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"10","url":"/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":11}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"11","url":"/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":12}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"12","url":"/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":13}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"13","url":"/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":14}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"14","url":"/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":15}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"15","url":"/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":16}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"16","url":"/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:42 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":17}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"17","url":"/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:43 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":18}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"18","url":"/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:43 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":19}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"19","url":"/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":20}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"20","url":"/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":21}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"21","url":"/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":22}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"22","url":"/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":23}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"23","url":"/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":24}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"24","url":"/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":25}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"25","url":"/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":26}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"26","url":"/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":27}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"27","url":"/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":28}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"28","url":"/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":29}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"29","url":"/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":30}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:46:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"30","url":"/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:46:48 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&orderBy=number&page=1&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:47:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '348'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '151'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogItemsWithProperties":[{"catalogName":"example-catalog","itemId":"30","size":13,"lastModified":1560962808000,"value":{"number":30}},{"catalogName":"example-catalog","itemId":"29","size":13,"lastModified":1560962807000,"value":{"number":29}},{"catalogName":"example-catalog","itemId":"28","size":13,"lastModified":1560962807000,"value":{"number":28}},{"catalogName":"example-catalog","itemId":"27","size":13,"lastModified":1560962807000,"value":{"number":27}},{"catalogName":"example-catalog","itemId":"26","size":13,"lastModified":1560962806000,"value":{"number":26}},{"catalogName":"example-catalog","itemId":"25","size":13,"lastModified":1560962806000,"value":{"number":25}},{"catalogName":"example-catalog","itemId":"24","size":13,"lastModified":1560962805000,"value":{"number":24}},{"catalogName":"example-catalog","itemId":"23","size":13,"lastModified":1560962805000,"value":{"number":23}},{"catalogName":"example-catalog","itemId":"22","size":13,"lastModified":1560962805000,"value":{"number":22}},{"catalogName":"example-catalog","itemId":"21","size":13,"lastModified":1560962804000,"value":{"number":21}}],"totalItemsCount":30,"nextPageUrl":"/api/catalogs/example-catalog/items?pageSize=10&orderBy=number&sortAscending=false&api_key=<ITERABLE_TOKEN>&page=2"}}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:47:48 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jun 2019 16:47:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '927'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 16:47:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_page_number/returns_the_given_page_of_items.yml
+++ b/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_page_number/returns_the_given_page_of_items.yml
@@ -1,0 +1,1399 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2742'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1068,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:31 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":1}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:31 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":2}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","url":"/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:32 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":3}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"3","url":"/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:32 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":4}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"4","url":"/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:33 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":5}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"5","url":"/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:34 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":6}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"6","url":"/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:34 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":7}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"7","url":"/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":8}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"8","url":"/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:35 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":9}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"9","url":"/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:37 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":10}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"10","url":"/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":11}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"11","url":"/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":12}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"12","url":"/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:38 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":13}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"13","url":"/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":14}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"14","url":"/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":15}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"15","url":"/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:39 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":16}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"16","url":"/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":17}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"17","url":"/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":18}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"18","url":"/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":19}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"19","url":"/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":20}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"20","url":"/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":21}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"21","url":"/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:42 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":22}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"22","url":"/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":23}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"23","url":"/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":24}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"24","url":"/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":25}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"25","url":"/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":26}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"26","url":"/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":27}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"27","url":"/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:48 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":28}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"28","url":"/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:49 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":29}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"29","url":"/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:49 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":30}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"30","url":"/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:49 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:10:49 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        Json error: {"obj.mappingsUpdates[0]":[{"msg":["error.expected.jsobject"],"args":[]}],"obj.mappingsUpdates[1]":[{"msg":["error.expected.jsobject"],"args":[]}]}
+         {"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:10:49 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&page=2&pageSize=10&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:11:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '351'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogItemsWithProperties":[{"catalogName":"example-catalog","itemId":"19","size":13,"lastModified":1559574641000,"value":{"number":19}},{"catalogName":"example-catalog","itemId":"20","size":13,"lastModified":1559574641000,"value":{"number":20}},{"catalogName":"example-catalog","itemId":"16","size":13,"lastModified":1559574640000,"value":{"number":16}},{"catalogName":"example-catalog","itemId":"17","size":13,"lastModified":1559574640000,"value":{"number":17}},{"catalogName":"example-catalog","itemId":"18","size":13,"lastModified":1559574640000,"value":{"number":18}},{"catalogName":"example-catalog","itemId":"13","size":13,"lastModified":1559574639000,"value":{"number":13}},{"catalogName":"example-catalog","itemId":"14","size":13,"lastModified":1559574639000,"value":{"number":14}},{"catalogName":"example-catalog","itemId":"15","size":13,"lastModified":1559574639000,"value":{"number":15}},{"catalogName":"example-catalog","itemId":"10","size":13,"lastModified":1559574638000,"value":{"number":10}},{"catalogName":"example-catalog","itemId":"11","size":13,"lastModified":1559574638000,"value":{"number":11}}],"totalItemsCount":30,"nextPageUrl":"/api/catalogs/example-catalog/items?pageSize=10&sortAscending=false&api_key=<ITERABLE_TOKEN>&page=3","previousPageUrl":"/api/catalogs/example-catalog/items?pageSize=10&sortAscending=false&api_key=<ITERABLE_TOKEN>&page=1"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:11:50 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:11:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '884'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:11:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_page_size/returns_the_given_number_of_items.yml
+++ b/spec/cassettes/Iterable_Catalog/items/with_an_existing_catalog/with_a_page_size/returns_the_given_number_of_items.yml
@@ -1,0 +1,1399 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '147'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2725'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1071,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":1}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"1","url":"/api/catalogs/example-catalog/items/1?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":2}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"2","url":"/api/catalogs/example-catalog/items/2?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":3}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"3","url":"/api/catalogs/example-catalog/items/3?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:41 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":4}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"4","url":"/api/catalogs/example-catalog/items/4?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:42 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":5}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"5","url":"/api/catalogs/example-catalog/items/5?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":6}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"6","url":"/api/catalogs/example-catalog/items/6?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:45 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":7}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"7","url":"/api/catalogs/example-catalog/items/7?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":8}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"8","url":"/api/catalogs/example-catalog/items/8?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":9}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"9","url":"/api/catalogs/example-catalog/items/9?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":10}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"10","url":"/api/catalogs/example-catalog/items/10?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":11}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"11","url":"/api/catalogs/example-catalog/items/11?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":12}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"12","url":"/api/catalogs/example-catalog/items/12?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:47 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":13}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"13","url":"/api/catalogs/example-catalog/items/13?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:48 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":14}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"14","url":"/api/catalogs/example-catalog/items/14?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:48 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":15}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"15","url":"/api/catalogs/example-catalog/items/15?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:49 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":16}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"16","url":"/api/catalogs/example-catalog/items/16?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:49 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":17}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"17","url":"/api/catalogs/example-catalog/items/17?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:50 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":18}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"18","url":"/api/catalogs/example-catalog/items/18?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:50 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":19}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"19","url":"/api/catalogs/example-catalog/items/19?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:50 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":20}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"20","url":"/api/catalogs/example-catalog/items/20?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:51 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":21}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"21","url":"/api/catalogs/example-catalog/items/21?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:51 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":22}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"22","url":"/api/catalogs/example-catalog/items/22?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:52 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":23}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"23","url":"/api/catalogs/example-catalog/items/23?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:52 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":24}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"24","url":"/api/catalogs/example-catalog/items/24?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:53 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":25}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"25","url":"/api/catalogs/example-catalog/items/25?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:53 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":26}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"26","url":"/api/catalogs/example-catalog/items/26?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:54 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":27}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"27","url":"/api/catalogs/example-catalog/items/27?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:14:57 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":28}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:14:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"28","url":"/api/catalogs/example-catalog/items/28?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:15:04 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":29}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:15:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"29","url":"/api/catalogs/example-catalog/items/29?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:15:07 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"number":30}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:15:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"30","url":"/api/catalogs/example-catalog/items/30?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:15:07 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:15:08 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        Json error: {"obj.mappingsUpdates[0]":[{"msg":["error.expected.jsobject"],"args":[]}],"obj.mappingsUpdates[1]":[{"msg":["error.expected.jsobject"],"args":[]}]}
+         {"mappingsUpdates":[["fieldName","number"],["fieldType","long"]]}
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:15:08 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items?api_key=<ITERABLE_TOKEN>&page=1&pageSize=5&sortAscending=false
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:16:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '314'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogItemsWithProperties":[{"catalogName":"example-catalog","itemId":"30","size":13,"lastModified":1559574907000,"value":{"number":30}},{"catalogName":"example-catalog","itemId":"29","size":13,"lastModified":1559574905000,"value":{"number":29}},{"catalogName":"example-catalog","itemId":"28","size":13,"lastModified":1559574899000,"value":{"number":28}},{"catalogName":"example-catalog","itemId":"27","size":13,"lastModified":1559574895000,"value":{"number":27}},{"catalogName":"example-catalog","itemId":"26","size":13,"lastModified":1559574894000,"value":{"number":26}}],"totalItemsCount":30,"nextPageUrl":"/api/catalogs/example-catalog/items?pageSize=5&sortAscending=false&api_key=<ITERABLE_TOKEN>&page=2"}}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:16:08 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2019 15:16:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '871'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 15:16:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/remove/non-existing_catalog/fails.yml
+++ b/spec/cassettes/Iterable_Catalog/remove/non-existing_catalog/fails.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '120'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Received request to deleted item ID 123 from catalog elbatelpmaxe","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/remove/non-existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/remove/non-existing_catalog/responds_with_success.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/elbatelpmaxe/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '120'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Received request to deleted item ID 123 from catalog elbatelpmaxe","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:05 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Received request to deleted item ID 123 from catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/remove/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/remove/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3533'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":988,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:08 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Received request to deleted item ID 123 from catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:09 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '872'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/remove/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/remove/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3593'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":989,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:13 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"foo":"bar"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:13 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '103'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        Json error: {"obj.update":[{"msg":["error.path.missing"],"args":[]}]}
+         {"foo":"bar"}
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:13 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '4'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Received request to deleted item ID 123 from catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:14 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:11:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '872'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:11:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/remove/with_an_existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/remove/with_an_existing_catalog/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3467'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":987,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:32 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Received request to deleted item ID 123 from catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:32 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:06:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '879'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:06:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/non-existing_catalog/fails_with_code_400.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/non-existing_catalog/fails_with_code_400.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:11:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Failed to upload into example-catalog. You are trying to access
+        catalog example-catalog, but it does not yet exist. Please see our API docs
+        to explicitly create the catalog.","code":"BadParams","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:11:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_a_non-existant_key/creates_the_record.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_a_non-existant_key/creates_the_record.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3836'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1030,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:46 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:46 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:11:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '159'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":35,"lastModified":1559358646000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:11:46 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:11:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '959'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:11:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3811'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1029,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:40 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:41 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '937'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/adds_new_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/adds_new_fields.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:08:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2721'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1028,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:08:34 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:08:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '22'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:08:34 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:09:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '19'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:09:34 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '159'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":35,"lastModified":1559358574000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:35 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:10:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '744'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:10:36 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/removes_extra_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/removes_extra_fields.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:06:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '147'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2812'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1027,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:06:29 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:06:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:06:29 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:07:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '14'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:07:30 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:08:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '159'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":35,"lastModified":1559358449000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:08:30 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:08:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '962'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:08:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:03:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2844'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1025,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:03:20 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:03:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:03:20 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:04:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:04:20 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:04:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '931'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:04:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/updates_existing_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/replace/with_an_existing_catalog/for_an_existing_key/updates_existing_fields.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:04:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3105'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1026,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:04:25 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:04:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '17'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:04:25 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:05:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '16'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:05:25 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:06:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '159'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":35,"lastModified":1559358325000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:06:25 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:06:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '938'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:06:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/non-existing_catalog/fails_with_code_400.yml
+++ b/spec/cassettes/Iterable_Catalog/update/non-existing_catalog/fails_with_code_400.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 03:00:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Failed to upload into example-catalog. You are trying to access
+        catalog example-catalog, but it does not yet exist. Please see our API docs
+        to explicitly create the catalog.","code":"BadParams","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 03:00:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/non-existing_catalog/returns_404.yml
+++ b/spec/cassettes/Iterable_Catalog/update/non-existing_catalog/returns_404.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:43:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '6'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Failed to upload into example-catalog. You are trying to access
+        catalog example-catalog, but it does not yet exist. Please see our API docs
+        to explicitly create the catalog.","code":"BadParams","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:43:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_a_non-existant_key/creates_the_record.yml
+++ b/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_a_non-existant_key/creates_the_record.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:51:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '147'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3817'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1017,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:51:09 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:51:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:51:09 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:52:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '159'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":35,"lastModified":1559357469000,"value":{"orange":"julius","lemon":"wedge"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:52:09 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:52:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '943'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:52:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_a_non-existant_key/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:51:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3809'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1016,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:51:04 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:51:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:51:04 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:51:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '919'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:51:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/adds_new_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/adds_new_fields.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:43:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1748'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1012,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:43:44 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:43:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '17'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:43:44 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:44:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:44:44 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:45:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '164'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":50,"lastModified":1559357084000,"value":{"lime":"juice","lemon":"wedge","orange":"julius"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:45:44 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:45:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '885'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:45:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/leaves_unmodified_fields_alone.yml
+++ b/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/leaves_unmodified_fields_alone.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:47:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2861'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1014,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:47:54 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:47:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '9'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:47:54 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:48:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:48:54 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:49:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '164'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '20'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":50,"lastModified":1559357334000,"value":{"lime":"juice","lemon":"wedge","orange":"julius"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:49:54 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:49:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '990'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:49:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/responds_with_success.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:49:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2882'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1015,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:49:58 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:49:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:49:59 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:50:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '17'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:50:59 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:51:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '938'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:51:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/updates_existing_fields.yml
+++ b/spec/cassettes/Iterable_Catalog/update/with_an_existing_catalog/for_an_existing_key/updates_existing_fields.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:45:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3572'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":1013,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:45:49 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"value":{"lime":"juice","lemon":"slice"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:45:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:45:49 GMT
+- request:
+    method: patch
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"update":{"orange":"julius","lemon":"wedge"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:46:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '23'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","url":"/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:46:50 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/items/123?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:47:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '164'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"catalogName":"example-catalog","itemId":"123","size":50,"lastModified":1559357210000,"value":{"lime":"juice","lemon":"wedge","orange":"julius"}}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:47:50 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:47:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '908'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:47:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update_field_mappings/non-existing_catalog/fails_with_code_500.yml
+++ b/spec/cassettes/Iterable_Catalog/update_field_mappings/non-existing_catalog/fails_with_code_500.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[{"fieldName":"exampleString","fieldType":"string"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"An error occured. Please try again later. If problem persists,
+        please contact your CSM","code":"GenericError","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update_field_mappings/with_an_existing_catalog/responds_with_success.yml
+++ b/spec/cassettes/Iterable_Catalog/update_field_mappings/with_an_existing_catalog/responds_with_success.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2715'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":993,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:15 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[{"fieldName":"exampleString","fieldType":"string"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '59'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:15 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '872'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update_field_mappings/with_an_existing_catalog/updates_the_field_mappings.yml
+++ b/spec/cassettes/Iterable_Catalog/update_field_mappings/with_an_existing_catalog/updates_the_field_mappings.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2794'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":994,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:19 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[{"fieldName":"exampleString","fieldType":"string"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '59'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:19 GMT
+- request:
+    method: get
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '111'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '11'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"definedMappings":{"exampleString":"string"},"undefinedFields":[]}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:19 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '848'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Iterable_Catalog/update_field_mappings/with_an_existing_catalog/with_invalid_params/fails_with_code_400.yml
+++ b/spec/cassettes/Iterable_Catalog/update_field_mappings/with_an_existing_catalog/with_invalid_params/fails_with_code_400.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '2815'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"","code":"Success","params":{"id":995,"name":"example-catalog","url":"/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>"}}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:23 GMT
+- request:
+    method: put
+    uri: https://api.iterable.com/api/catalogs/example-catalog/fieldMappings?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: '{"mappingsUpdates":[{"something":"wicked"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:23 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '146'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        Json error: {"obj.mappingsUpdates[0].fieldName":[{"msg":["error.path.missing"],"args":[]}],"obj.mappingsUpdates[0].fieldType":[{"msg":["error.path.missing"],"args":[]}]}
+         {"mappingsUpdates":[{"something":"wicked"}]}
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:23 GMT
+- request:
+    method: delete
+    uri: https://api.iterable.com/api/catalogs/example-catalog?api_key=<ITERABLE_TOKEN>
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.iterable.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Jun 2019 02:14:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Origin,Accept-Encoding
+      Request-Time:
+      - '872'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"msg":"Successfully deleted catalog example-catalog","code":"Success","params":null}'
+    http_version: 
+  recorded_at: Sat, 01 Jun 2019 02:14:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/iterable/catalog_spec.rb
+++ b/spec/lib/iterable/catalog_spec.rb
@@ -1,0 +1,479 @@
+require 'spec_helper'
+require 'securerandom'
+
+RSpec.describe Iterable::Catalog, :vcr do
+  let(:name) { 'example-catalog' }
+  let(:catalog) { described_class.new(name) }
+
+  describe 'field_mappings' do
+    subject(:res) { catalog.field_mappings }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+
+      it 'returns defined mappings' do
+        expect(res.body.dig('params', 'definedMappings')).to be_a Hash
+      end
+
+      it 'returns a list of undefined fields' do
+        expect(res.body.dig('params', 'undefinedFields')).to be_a Array
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'fails with code 500' do
+        expect(res.code).to eq '500'
+      end
+    end
+  end
+
+  describe 'update_field_mappings' do
+    subject(:res) { catalog.update_field_mappings(mappings) }
+
+    let(:mapping) { { fieldName: 'exampleString', fieldType: 'string' } }
+    let(:mappings) { [mapping] }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+
+      it 'updates the field mappings' do
+        res
+        expect(catalog.field_mappings.body.dig('params', 'definedMappings', 'exampleString')).to eq 'string'
+      end
+
+      context 'with invalid params' do
+        let(:mapping) { { something: 'wicked' } }
+
+        it 'fails with code 400' do
+          expect(res.code).to eq '400'
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'fails with code 500' do
+        expect(res.code).to eq '500'
+      end
+    end
+  end
+
+  describe 'delete' do
+    subject(:res) { catalog.delete }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'fails' do
+        pending 'this currently returns 200'
+        expect(res).not_to be_success
+      end
+    end
+  end
+
+  describe 'create' do
+    subject(:res) { catalog.create }
+    after { catalog.delete }
+
+    it 'responds with success' do
+      expect(res).to be_success
+    end
+
+    context 'creating a duplicate catalog' do
+      before { catalog.create }
+
+      it 'fails with code 400' do
+        expect(res.code).to eq '400'
+      end
+    end
+  end
+
+  describe 'remove' do
+    let(:key) { 123 }
+    subject(:res) { catalog.remove(key) }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      context 'for an existing key' do
+        before { catalog.update(key, foo: 'bar') }
+
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+      end
+
+      context 'for a non-existant key' do
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+    end
+  end
+
+  describe 'get' do
+    let(:key) { 123 }
+    subject(:res) { catalog.get(key) }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      context 'for an existing key' do
+        before { catalog.update(key, foo: 'bar') }
+
+        # updating is async, so we have to wait a long time when recording cassettes
+        before { sleep 20 if ENV['RECORD_DELAY'] }
+
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+
+        it 'returns the requested item' do
+          expect(res.body.dig('params', 'value')).to eq('foo' => 'bar')
+        end
+      end
+
+      context 'for a non-existant key' do
+        it 'returns 404' do
+          expect(res.code).to eq '404'
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'returns 404' do
+        expect(res.code).to eq '404'
+      end
+    end
+  end
+
+  describe 'update' do
+    let(:key) { 123 }
+    let(:update_value) { { orange: 'julius', lemon: 'wedge' } }
+    subject(:res) { catalog.update(key, update_value) }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      context 'for an existing key' do
+        before { catalog.replace(key, lime: 'juice', lemon: 'slice') }
+
+        # updating is async, so we have to wait a long time when recording cassettes
+        before { sleep 20 if ENV['RECORD_DELAY'] }
+
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+
+        it 'adds new fields' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'orange')).to eq('julius')
+        end
+
+        it 'updates existing fields' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'lemon')).to eq('wedge')
+        end
+
+        it 'leaves unmodified fields alone' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'lime')).to eq('juice')
+        end
+      end
+
+      context 'for a non-existant key' do
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+
+        it 'creates the record' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'orange')).to eq('julius')
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'fails with code 400' do
+        expect(res.code).to eq '400'
+      end
+    end
+  end
+
+  describe 'replace' do
+    let(:key) { 123 }
+    let(:update_value) { { orange: 'julius', lemon: 'wedge' } }
+    subject(:res) { catalog.replace(key, update_value) }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      context 'for an existing key' do
+        before { catalog.replace(key, lime: 'juice', lemon: 'slice') }
+
+        # updating is async, so we have to wait a long time when recording cassettes
+        before { sleep 20 if ENV['RECORD_DELAY'] }
+
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+
+        it 'adds new fields' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'orange')).to eq('julius')
+        end
+
+        it 'updates existing fields' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'lemon')).to eq('wedge')
+        end
+
+        it 'removes extra fields' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'lime')).to be_nil
+        end
+      end
+
+      context 'for a non-existant key' do
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+
+        it 'creates the record' do
+          res
+          sleep 20 if ENV['RECORD_DELAY']
+          expect(catalog.get(key).body.dig('params', 'value', 'orange')).to eq('julius')
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'fails with code 400' do
+        expect(res.code).to eq '400'
+      end
+    end
+  end
+
+  describe 'bulk_remove' do
+    let(:key) { 123 }
+    subject(:res) { catalog.bulk_remove(key) }
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      context 'for an existing key' do
+        before { catalog.update(key, foo: 'bar') }
+        # updating is async, so we have to wait a long time when recording cassettes
+        before { sleep 20 if ENV['RECORD_DELAY'] }
+
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+      end
+
+      context 'for a non-existant key' do
+        it 'responds with success' do
+          expect(res).to be_success
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+    end
+  end
+
+  describe 'items' do
+    let(:key) { 123 }
+    subject(:res) { catalog.items }
+
+    context 'with an existing catalog' do
+      before do
+        catalog.create
+        catalog.update_field_mappings(fieldName: 'number', fieldType: 'long')
+        1.upto(30).each { |i| catalog.replace(i, number: i) }
+      end
+
+      # updating is async, so we have to wait a long time when recording cassettes
+      before { sleep 20 if ENV['RECORD_DELAY'] }
+
+      after { catalog.delete }
+
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+
+      it 'returns the first page of items' do
+        expect(res.body.dig('params', 'catalogItemsWithProperties').size).to eq 10
+      end
+
+      context 'with a page number' do
+        subject(:res) { catalog.items(page: 2) }
+
+        it 'returns the given page of items' do
+          expect(res.body.dig('params', 'previousPageUrl')).to include 'page=1'
+          expect(res.body.dig('params', 'nextPageUrl')).to include 'page=3'
+        end
+      end
+
+      context 'with a page size' do
+        subject(:res) { catalog.items(page_size: 5) }
+
+        it 'returns the given number of items' do
+          expect(res.body.dig('params', 'catalogItemsWithProperties').size).to eq 5
+        end
+      end
+
+      context 'with a given order' do
+        context 'and ascending sort' do
+          subject(:res) { catalog.items(order: 'number', sort_ascending: true) }
+
+          it 'sorts the items ascending' do
+            expect(
+              res.body.dig('params', 'catalogItemsWithProperties').map { |c| c.dig('value', 'number') }
+            ).to eq [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+          end
+        end
+
+        context 'and non-ascending sort' do
+          subject(:res) { catalog.items(order: 'number', sort_ascending: false) }
+
+          it 'sorts the items descending' do
+            expect(
+              res.body.dig('params', 'catalogItemsWithProperties').map { |c| c.dig('value', 'number') }
+            ).to eq [30, 29, 28, 27, 26, 25, 24, 23, 22, 21]
+          end
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'returns 404' do
+        expect(res.code).to eq '404'
+      end
+    end
+  end
+
+  describe 'bulk_create' do
+    let(:item1) { { orange: 'julius', lemon: 'wedge' } }
+    let(:item2) { { orange: 'slice', lemon: 'head' } }
+    let(:documents) { { 1 => item1, 2 => item2 } }
+    let(:replace_uploaded_fields_only) { true }
+
+    subject(:res) do
+      catalog.bulk_create(
+        documents: documents,
+        replace_uploaded_fields_only: replace_uploaded_fields_only
+      )
+    end
+
+    context 'with an existing catalog' do
+      before { catalog.create }
+      after { catalog.delete }
+
+      it 'responds with success' do
+        expect(res).to be_success
+      end
+
+      it 'creates the records' do
+        res
+        sleep 40 if ENV['RECORD_DELAY']
+
+        expect(catalog.get(1).body.dig('params', 'value', 'orange')).to eq('julius')
+        expect(catalog.get(2).body.dig('params', 'value', 'orange')).to eq('slice')
+      end
+
+      context 'with an existing record' do
+        before { catalog.replace(1, lime: 'juice', lemon: 'slice') }
+
+        # updating is async, so we have to wait a long time when recording cassettes
+        before { sleep 20 if ENV['RECORD_DELAY'] }
+
+        context 'when replacing only uploaded fields' do
+          let(:replace_uploaded_fields_only) { true }
+
+          it 'adds new fields' do
+            res
+            sleep 20 if ENV['RECORD_DELAY']
+            expect(catalog.get(1).body.dig('params', 'value', 'orange')).to eq('julius')
+          end
+
+          it 'updates existing fields' do
+            res
+            sleep 20 if ENV['RECORD_DELAY']
+            expect(catalog.get(1).body.dig('params', 'value', 'lemon')).to eq('wedge')
+          end
+
+          it 'leaves unmodified fields alone' do
+            res
+            sleep 20 if ENV['RECORD_DELAY']
+            expect(catalog.get(1).body.dig('params', 'value', 'lime')).to eq('juice')
+          end
+        end
+
+        context 'when replacing entire records fields' do
+          let(:replace_uploaded_fields_only) { false }
+
+          it 'adds new fields' do
+            res
+            sleep 20 if ENV['RECORD_DELAY']
+            expect(catalog.get(1).body.dig('params', 'value', 'orange')).to eq('julius')
+          end
+
+          it 'updates existing fields' do
+            res
+            sleep 20 if ENV['RECORD_DELAY']
+            expect(catalog.get(1).body.dig('params', 'value', 'lemon')).to eq('wedge')
+          end
+
+          it 'removes extra fields' do
+            res
+            sleep 20 if ENV['RECORD_DELAY']
+            expect(catalog.get(1).body.dig('params', 'value', 'lime')).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'non-existing catalog' do
+      it 'returns 404' do
+        expect(res.code).to eq '404'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the new Iterable Catalogs API, currently in beta.
> https://api.iterable.com/api/docs#catalogs_listCatalogs

This API is currently only available when using an API key that has been
granted beta access to catalogs.

Note: a lot of the functionality provided by this API is asynchronous,
so it's hard to guarantee that pre-conditions for the integration tests
have been properly set up without allowing time for the work to settle.

I've worked around this by adding a RECORD_DELAY environment variable
which will insert appropriate delays into the test suite to wait for the
async work to complete. This is far from ideal, but is only required when
recording new VCR cassettes.