### PR TITLE
Fix Readme for proper usage of field_mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,8 @@ Endpoint: `GET /catalogs/{catalogName}/fieldMappings`
 ```ruby
 catalog = 'my-catalog'
 catalog_field_mappings = Iterable::CatalogFieldMappings.new(catalog)
-response = catalog_field_mappings.field_mappings
+response = catalog_field_mappings.get
+response.body['params']['definedMappings']
 ```
 
 #### Catalog Field Mappings Update


### PR DESCRIPTION
Looks like original method was never implemented in `/lib/iterable/catalog_field_mappings.rb`